### PR TITLE
Fix reliability bugs, scheduled task security, and OS detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,6 @@ To run the script automatically after updates, import the task into Windows Task
  - Windows 10
  - Windows 11 22H2, 23H2, 24H2, 25H2
  - Windows Server 2016
- - Windows Server 2022
+ - Windows Server 2019
+ - Windows Server 2022 (including Datacenter Azure Edition / HCI, build 25398)
  - Windows Server 2025

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ To run the script automatically after updates, import the task into Windows Task
 2. **Import**: Select _Action_ > _Import Task..._ and choose [TermsrvPatcherScheduledTask.xml](TermsrvPatcherScheduledTask.xml).
 3. **Configure Path**: The default path is `C:\TermsrvPatcher.ps1`. If your script is elsewhere, go to _Actions_ > _Edit_ and update the script path in the _Arguments_ input.
 
+> **Security notice:** The scheduled task runs as SYSTEM with `HighestAvailable` privileges and passes `-ExecutionPolicy Bypass` to PowerShell. These settings are required because the task must modify a protected system file (`termsrv.dll`) without a UAC prompt at boot. The practical consequence is that **whoever controls the script file controls what runs as SYSTEM** — ensure `TermsrvPatcher.ps1` is stored in a location writable only by Administrators (e.g. `C:\` or `C:\Program Files`), not in a user-writable folder such as `Downloads` or `AppData`. Do not use this scheduled task on shared or multi-tenant systems where non-administrator users could replace the script.
+
 
 # Supported Terminal Services versions:
  - Windows 7 Pro SP1 64-bit
- - Windows 10 and Windows 11 23H2/24H2
+ - Windows 10
+ - Windows 11 22H2, 23H2, 24H2, 25H2
  - Windows Server 2016
  - Windows Server 2022
+ - Windows Server 2025

--- a/TermsrvPatcher.ps1
+++ b/TermsrvPatcher.ps1
@@ -2,7 +2,7 @@
 
 <#PSScriptInfo
 
-.VERSION 1.0
+.VERSION 1.1
 
 .GUID 41543292-9400-41d5-8bb8-5fe43f167a03
 
@@ -71,17 +71,20 @@ function Get-OSVersion {
             return 'Windows 7'
         } elseif ($OSVersion.Major -eq 10 -and $OSVersion.Build -lt 22000) {
             return 'Windows 10'
-        } elseif ($OSVersion.Major -eq 10 -and $OSVersion.Build -gt 22000) {
+        } elseif ($OSVersion.Major -eq 10 -and $OSVersion.Build -ge 22000) {
             return 'Windows 11'
         } else {
             return 'Unsupported OS'
         }
     } elseif ($installationType -eq 'Server') {
-        if ($OSVersion.Major -eq 10 -and $OSVersion.Build -lt 22000) {
+        # Use explicit build numbers instead of ranges — Server 2022 (20348) is < 22000,
+        # so a -lt 22000 range check would incorrectly match it as Server 2016.
+        if ($OSVersion.Major -eq 10 -and $OSVersion.Build -eq 14393) {
             return 'Windows Server 2016'
-        } elseif ($OSVersion.Major -eq 10 -and $OSVersion.Build -eq 20348) {
+        } elseif ($OSVersion.Major -eq 10 -and ($OSVersion.Build -eq 20348 -or $OSVersion.Build -eq 25398)) {
+            # 20348 = Server 2022; 25398 = Server 2022 Datacenter Azure Edition (HCI)
             return 'Windows Server 2022'
-        } elseif ($OSVersion.Major -eq 10 -and $OSVersion.Build -eq 26100) {
+        } elseif ($OSVersion.Major -eq 10 -and $OSVersion.Build -ge 26100) {
             return 'Windows Server 2025'
         } else {
             return 'Unsupported OS'
@@ -89,6 +92,43 @@ function Get-OSVersion {
     } else {
         return 'Unsupported OS'
     }
+}
+
+# Retry Copy-Item up to 30 times with a 2-second delay to handle the window where dependent
+# services have stopped but still hold a file lock on termsrv.dll.
+function Copy-DllWithRetry {
+    param(
+        [string]$Source,
+        [string]$Destination
+    )
+    for ($i = 1; $i -le 30; $i++) {
+        try {
+            Copy-Item -Path $Source -Destination $Destination -Force -ErrorAction Stop
+            return $true
+        } catch {
+            Write-Host "Waiting for DLL lock to release (attempt $i/30)..." -ForegroundColor Yellow
+            Start-Sleep -Milliseconds 2000
+        }
+    }
+    return $false
+}
+
+function Stop-TermService {
+    # Stop dependent services first; they can hold termsrv.dll open even after TermService stops.
+    Stop-Service -Name UmRdpService, SessionEnv -Force -ErrorAction SilentlyContinue
+
+    try {
+        Stop-Service -Name TermService -Force -ErrorAction Stop
+    } catch {
+        Write-Warning -Message $_.Exception.Message
+        exit 1  # exit the script, not just this function
+    }
+
+    while ((Get-Service -Name TermService).Status -ne 'Stopped') {
+        Start-Sleep -Milliseconds 500
+    }
+
+    Write-Host "`nThe Remote Desktop Services (TermService) has been stopped successfully`n" -ForegroundColor Green
 }
 
 function Update-Dll {
@@ -115,14 +155,17 @@ function Update-Dll {
 
     begin {
         $match = $TermsrvDllAsText -match $InputPattern
-        $patch = $TermsrvDllAsText -match $Replacement
+        # Use .Contains() for a literal string check — $Replacement is not a regex pattern.
+        $patch = $TermsrvDllAsText.Contains($Replacement)
     }
 
     process {
         if ($match) {
             Write-Host "`nPattern matching!`n" -ForegroundColor Green
 
-            $dllAsTextReplaced = $TermsrvDllAsText -replace $InputPattern, $Replacement
+            # Replace only the first occurrence to avoid corrupting the DLL if the
+            # byte sequence appears more than once.
+            $dllAsTextReplaced = $InputPattern.Replace($TermsrvDllAsText, $Replacement, 1)
 
             # Use the replaced string to create a byte array again.
             [byte[]] $dllAsBytesReplaced = -split $dllAsTextReplaced -replace '^', '0x'
@@ -151,8 +194,12 @@ function Update-Dll {
 
             Start-Sleep -Milliseconds 1500
 
-            # Overwrite original DLL with patched version:
-            Copy-Item -Path $TermsrvDllAsPatch -Destination $TermsrvDllAsFile -Force
+            if (-not (Copy-DllWithRetry -Source $TermsrvDllAsPatch -Destination $TermsrvDllAsFile)) {
+                Write-Warning 'Could not replace termsrv.dll after 30 attempts. Try rebooting and running the script again.'
+                Set-Acl -Path $TermsrvDllAsFile -AclObject $TermsrvAclObject
+                Start-Service TermService -PassThru
+                exit 1
+            }
         } elseif ($patch) {
             Write-Host "The file is already patched. No changes are needed.`n" -ForegroundColor Green
         } else {
@@ -167,21 +214,6 @@ function Update-Dll {
     }
 }
 
-function Stop-TermService {
-    try {
-        Stop-Service -Name TermService -Force -ErrorAction Stop
-    } catch {
-        Write-Warning -Message $_.Exception.Message
-        return
-    }
-
-    while ((Get-Service -Name TermService).Status -ne 'Stopped') {
-        Start-Sleep -Milliseconds 500
-    }
-
-    Write-Host "`nThe Remote Desktop Services (TermService) has been stopped sucsessfully`n" -ForegroundColor Green
-}
-
 Stop-TermService
 
 # Save Access Control List (ACL) of termsrv.dll file.
@@ -189,17 +221,35 @@ $termsrvDllAcl = Get-Acl -Path $termsrvDllFile
 
 Write-Host "Owner of termsrv.dll: $($termsrvDllAcl.Owner)"
 
-# Create a backup of the original termsrv.dll file.
-Copy-Item -Path $termsrvDllFile -Destination $termsrvDllCopy -Force
+# Only create a backup when one does not already exist. Always overwriting risks replacing a
+# clean original backup with a patched copy on subsequent runs.
+if (-not (Test-Path $termsrvDllCopy)) {
+    Copy-Item -Path $termsrvDllFile -Destination $termsrvDllCopy -Force
+    Write-Host "Backup created at $termsrvDllCopy" -ForegroundColor Cyan
+} else {
+    Write-Host "Backup already exists at $termsrvDllCopy, skipping." -ForegroundColor Cyan
+}
 
 # Take ownership of the DLL...
 takeown.exe /F $termsrvDllFile
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "takeown failed (exit code $LASTEXITCODE). Cannot proceed."
+    Set-Acl -Path $termsrvDllFile -AclObject $termsrvDllAcl
+    Start-Service TermService -PassThru
+    exit 1
+}
 
 # Get Current logged in user (changed by .NET class, because in remote connection WMI Object cannot retrieve the user)
 $currentUserName = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
 
 # Grant full control to the currently logged in user.
 icacls.exe $termsrvDllFile /grant "$($currentUserName):F"
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "icacls failed (exit code $LASTEXITCODE). Cannot proceed."
+    Set-Acl -Path $termsrvDllFile -AclObject $termsrvDllAcl
+    Start-Service TermService -PassThru
+    exit 1
+}
 
 # Read termsrv.dll as byte array to modify bytes
 $dllAsByte = [System.IO.File]::ReadAllBytes($termsrvDllFile)
@@ -217,54 +267,65 @@ $commonParams = @{
 switch (Get-OSVersion) {
     'Windows 7' {
         if ($OSArchitecture -eq '64-bit') {
-            switch ((Get-OSInfo).FullOSBuild) {
-                '7601.23964' {
-                    $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 2F C3 00 00', 'B8 00 01 00 00 90 89 87 38 06 00 00 90 90 90 90 90 90' `
-                    -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
-                    -replace '83 7C 24 50 00 74 18 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+            $win7Replacement = 'B8 00 01 00 00 90 89 87 38 06 00 00 90 90 90 90 90 90'
+
+            if ($dllAsText.Contains($win7Replacement)) {
+                Write-Host "The file is already patched. No changes are needed.`n" -ForegroundColor Green
+            } else {
+                switch ((Get-OSInfo).FullOSBuild) {
+                    '7601.23964' {
+                        $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 2F C3 00 00', $win7Replacement `
+                        -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
+                        -replace '83 7C 24 50 00 74 18 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+                    }
+                    '7601.24546' {
+                        $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00', $win7Replacement `
+                        -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
+                        -replace '83 7C 24 50 00 74 43 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+                    }
+                    Default {
+                        $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00', $win7Replacement `
+                        -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
+                        -replace '83 7C 24 50 00 74 43 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+                    }
                 }
-                '7601.24546' {
-                    $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00', 'B8 00 01 00 00 90 89 87 38 06 00 00 90 90 90 90 90 90' `
-                    -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
-                    -replace '83 7C 24 50 00 74 43 48 8D', '83 7C 24 50 00 EB 18 48 8D'
-                }
-                Default {
-                    $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00', 'B8 00 01 00 00 90 89 87 38 06 00 00 90 90 90 90 90 90' `
-                    -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
-                    -replace '83 7C 24 50 00 74 43 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+
+                if ($dllAsTextReplaced -eq $dllAsText) {
+                    Write-Host "The pattern was not found. Nothing will be changed.`n" -ForegroundColor Yellow
+                } else {
+                    # Use the replaced string to create a byte array again.
+                    [byte[]] $dllAsBytesReplaced = -split $dllAsTextReplaced -replace '^', '0x'
+
+                    # Create termsrv.dll.patched from the byte array.
+                    [System.IO.File]::WriteAllBytes($termsrvPatched, $dllAsBytesReplaced)
+
+                    fc.exe /B $termsrvPatched $termsrvDllFile
+                    <#
+                    .DESCRIPTION
+                        Compares termsrv.dll with termsrv.dll.patched and displays the differences between them.
+                    .NOTES
+                        Expected output something like:
+
+                        00098BA2: B8 8B
+                        00098BA3: 00 99
+                        00098BA4: 01 30
+                        00098BA5: 00 03
+                        00098BA7: 89 00
+                        00098BA8: 81 8B
+                        00098BA9: 38 B1
+                        00098BAA: 06 34
+                        00098BAB: 00 03
+                        00098BAD: 90 00
+                    #>
+
+                    Start-Sleep -Milliseconds 1500
+
+                    if (-not (Copy-DllWithRetry -Source $termsrvPatched -Destination $termsrvDllFile)) {
+                        Write-Warning 'Could not replace termsrv.dll after 30 attempts. Try rebooting and running the script again.'
+                    }
                 }
             }
         }
-
-        # Use the replaced string to create a byte array again.
-        [byte[]] $dllAsBytesReplaced = -split $dllAsTextReplaced -replace '^', '0x'
-
-        # Create termsrv.dll.patched from the byte array.
-        [System.IO.File]::WriteAllBytes($termsrvPatched, $dllAsBytesReplaced)
-
-        fc.exe /B $termsrvPatched $termsrvDllFile
-        <#
-        .DESCRIPTION
-            Compares termsrv.dll with tersrv.dll.patched and displays the differences between them.
-        .NOTES
-            Expected output something like:
-
-            00098BA2: B8 8B
-            00098BA3: 00 99
-            00098BA4: 01 30
-            00098BA5: 00 03
-            00098BA7: 89 00
-            00098BA8: 81 8B
-            00098BA9: 38 B1
-            00098BAA: 06 34
-            00098BAB: 00 03
-            00098BAD: 90 00
-        #>
-
-        Start-Sleep -Milliseconds 1500
-
-        # Overwrite original DLL with patched version:
-        Copy-Item -Path $termsrvPatched -Destination $termsrvDllFile -Force
 
         # Restore original Access Control List (ACL):
         Set-Acl -Path $termsrvDllFile -AclObject $termsrvDllAcl
@@ -283,7 +344,9 @@ switch (Get-OSVersion) {
         } elseif ((Get-OSInfo).DisplayVersion -eq '24H2' -or (Get-OSInfo).DisplayVersion -eq '25H2') {
             Update-Dll @commonParams -InputPattern $patterns.Win24H2 -Replacement 'B8 00 01 00 00 89 81 38 06 00 00 90 EB'
         } else {
-          Write-Host "Win11 OS Info value [$((Get-OSInfo).DisplayVersion)] was not a supported value"
+            Write-Host "Win11 OS Info value [$((Get-OSInfo).DisplayVersion)] was not a supported value" -ForegroundColor Yellow
+            Set-Acl -Path $termsrvDllFile -AclObject $termsrvDllAcl
+            Start-Service TermService -PassThru
         }
     }
     'Windows Server 2016' {
@@ -296,6 +359,8 @@ switch (Get-OSVersion) {
         Update-Dll @commonParams -InputPattern $patterns.Pattern -Replacement 'B8 00 01 00 00 89 81 38 06 00 00 90'
     }
     'Unsupported OS' {
-        Write-Host 'Unable to get OS Version'
+        Write-Host 'Unable to get OS Version' -ForegroundColor Red
+        Set-Acl -Path $termsrvDllFile -AclObject $termsrvDllAcl
+        Start-Service TermService -PassThru
     }
 }

--- a/TermsrvPatcher.ps1
+++ b/TermsrvPatcher.ps1
@@ -81,6 +81,8 @@ function Get-OSVersion {
         # so a -lt 22000 range check would incorrectly match it as Server 2016.
         if ($OSVersion.Major -eq 10 -and $OSVersion.Build -eq 14393) {
             return 'Windows Server 2016'
+        } elseif ($OSVersion.Major -eq 10 -and $OSVersion.Build -eq 17763) {
+            return 'Windows Server 2019'
         } elseif ($OSVersion.Major -eq 10 -and ($OSVersion.Build -eq 20348 -or $OSVersion.Build -eq 25398)) {
             # 20348 = Server 2022; 25398 = Server 2022 Datacenter Azure Edition (HCI)
             return 'Windows Server 2022'
@@ -272,21 +274,28 @@ switch (Get-OSVersion) {
             if ($dllAsText.Contains($win7Replacement)) {
                 Write-Host "The file is already patched. No changes are needed.`n" -ForegroundColor Green
             } else {
+                $win7P2 = [regex]'4C 24 60 BB 01 00 00 00'
+                $win7P3_18 = [regex]'83 7C 24 50 00 74 18 48 8D'
+                $win7P3_43 = [regex]'83 7C 24 50 00 74 43 48 8D'
+
                 switch ((Get-OSInfo).FullOSBuild) {
                     '7601.23964' {
-                        $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 2F C3 00 00', $win7Replacement `
-                        -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
-                        -replace '83 7C 24 50 00 74 18 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+                        $p1 = [regex]'8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 2F C3 00 00'
+                        $dllAsTextReplaced = $p1.Replace($dllAsText, $win7Replacement, 1)
+                        $dllAsTextReplaced = $win7P2.Replace($dllAsTextReplaced, '4C 24 60 BB 00 00 00 00', 1)
+                        $dllAsTextReplaced = $win7P3_18.Replace($dllAsTextReplaced, '83 7C 24 50 00 EB 18 48 8D', 1)
                     }
                     '7601.24546' {
-                        $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00', $win7Replacement `
-                        -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
-                        -replace '83 7C 24 50 00 74 43 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+                        $p1 = [regex]'8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00'
+                        $dllAsTextReplaced = $p1.Replace($dllAsText, $win7Replacement, 1)
+                        $dllAsTextReplaced = $win7P2.Replace($dllAsTextReplaced, '4C 24 60 BB 00 00 00 00', 1)
+                        $dllAsTextReplaced = $win7P3_43.Replace($dllAsTextReplaced, '83 7C 24 50 00 EB 18 48 8D', 1)
                     }
                     Default {
-                        $dllAsTextReplaced = $dllAsText -replace '8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00', $win7Replacement `
-                        -replace '4C 24 60 BB 01 00 00 00', '4C 24 60 BB 00 00 00 00' `
-                        -replace '83 7C 24 50 00 74 43 48 8D', '83 7C 24 50 00 EB 18 48 8D'
+                        $p1 = [regex]'8B 87 38 06 00 00 39 87 3C 06 00 00 0F 84 3E C4 00 00'
+                        $dllAsTextReplaced = $p1.Replace($dllAsText, $win7Replacement, 1)
+                        $dllAsTextReplaced = $win7P2.Replace($dllAsTextReplaced, '4C 24 60 BB 00 00 00 00', 1)
+                        $dllAsTextReplaced = $win7P3_43.Replace($dllAsTextReplaced, '83 7C 24 50 00 EB 18 48 8D', 1)
                     }
                 }
 
@@ -350,6 +359,9 @@ switch (Get-OSVersion) {
         }
     }
     'Windows Server 2016' {
+        Update-Dll @commonParams -InputPattern $patterns.Pattern -Replacement 'B8 00 01 00 00 89 81 38 06 00 00 90'
+    }
+    'Windows Server 2019' {
         Update-Dll @commonParams -InputPattern $patterns.Pattern -Replacement 'B8 00 01 00 00 89 81 38 06 00 00 90'
     }
     'Windows Server 2022' {

--- a/TermsrvPatcherScheduledTask.xml
+++ b/TermsrvPatcherScheduledTask.xml
@@ -12,7 +12,7 @@
   <Principals>
     <Principal id="Author">
       <UserId>SYSTEM</UserId>
-      <RunLevel>LeastPrivilege</RunLevel>
+      <RunLevel>HighestAvailable</RunLevel>
     </Principal>
   </Principals>
   <Settings>
@@ -39,7 +39,7 @@
   <Actions Context="Author">
     <Exec>
       <Command>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</Command>
-      <Arguments>C:\TermsrvPatcher.ps1</Arguments>
+      <Arguments>-NoProfile -ExecutionPolicy Bypass -File "C:\TermsrvPatcher.ps1"</Arguments>
     </Exec>
   </Actions>
 </Task>


### PR DESCRIPTION
## Summary

- **DLL file-lock fix**: Added `Copy-DllWithRetry` helper that retries `Copy-Item` up to 30 times with 2-second delays, resolving the recurring `file in use` error reported in issues #4, #13, #15, and #18. Dependent services (`UmRdpService`, `SessionEnv`) are now explicitly stopped before `TermService` to release locks sooner.
- **Re-run safety**: Backup creation is now guarded with `Test-Path` so subsequent runs don't overwrite the original unpatched `.copy` with an already-patched version.
- **Script abort on failure**: `Stop-TermService` catch block changed from `return` (exits only the function) to `exit 1` (exits the script). `takeown.exe` and `icacls.exe` exit codes are now checked; on failure the ACL is restored and TermService is restarted before aborting.
- **Patch correctness**: `$patch` detection switched from `-match $Replacement` (regex) to `.Contains($Replacement)` (literal). First-occurrence-only replace via `Regex.Replace(..., 1)` prevents potential DLL corruption if the byte pattern appears more than once.
- **Win7 path hardened**: Added already-patched guard, pattern-not-found check, and `Copy-DllWithRetry`. Byte-writing moved inside the patching block so a failed pattern match can never write a null/empty byte array to disk.
- **Server OS detection fixed**: The previous `-lt 22000` range check incorrectly matched Server 2022 (build 20348) as Server 2016 — the `elseif` for build 20348 was dead code. Replaced with explicit build number checks. Added Server 2022 Datacenter Azure Edition / HCI (build 25398) and Server 2025 (build ≥ 26100).
- **Win11 build 22000 edge case**: `-gt 22000` changed to `-ge 22000` so build 22000 (21H2) is correctly identified as Windows 11.
- **Unsupported/error paths**: Win11 unrecognised version and `Unsupported OS` cases now restore the ACL and restart TermService instead of leaving both in a broken state.
- **Scheduled task fixed**: `RunLevel` changed from `LeastPrivilege` to `HighestAvailable` (required to write protected system files); `-NoProfile -ExecutionPolicy Bypass` added to `Arguments` so the task runs on machines with a restricted execution policy.
- **README**: Supported versions list updated to include Win11 25H2, Server 2022 HCI, and Server 2025. Security notice added under the scheduled task instructions explaining the implications of `HighestAvailable` and `-ExecutionPolicy Bypass`.

## Test plan

- [ ] Run on Windows 10 — verify patch applies and RDP allows multiple sessions
- [ ] Run on Windows 11 23H2 and 24H2/25H2 — verify correct pattern branch is selected
- [ ] Run twice in a row — verify "already patched" is detected and `.copy` backup is not overwritten
- [ ] Run on Windows Server 2022 — verify it is no longer misidentified as Server 2016
- [ ] Import updated scheduled task XML — verify task runs successfully at boot as SYSTEM
- [ ] Simulate DLL lock (leave a handle open) — verify retry loop waits and eventually succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)